### PR TITLE
TS-29729 Use the latest version of the Winston logger

### DIFF
--- a/packages/teamscale-coverage-collector/CHANGELOG.md
+++ b/packages/teamscale-coverage-collector/CHANGELOG.md
@@ -2,6 +2,8 @@ We use [Semantic Versioning](https://semver.org/).
 
 # New Release
 
+- [fix] The logger could not resolve a dependency ('../diagnostics')
+
 # 0.0.1-beta.22
 
 - [feature] Logging of the status text in case of an error when uploading to Teamscale added.  

--- a/packages/teamscale-coverage-collector/package.json
+++ b/packages/teamscale-coverage-collector/package.json
@@ -32,7 +32,7 @@
     "source-map": "^0.7.3",
     "tmp": "^0.2.1",
     "typescript-optional": "^2.0.1",
-    "winston": "^3.3.3",
+    "winston": "^3.6.0",
     "ws": "^7.4.5"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1306,7 +1306,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cqse/commons@^0.0.1-beta.1, @cqse/commons@^0.0.1-beta.25, @cqse/commons@workspace:packages/cqse-commons":
+"@cqse/commons@^0.0.1-beta.1, @cqse/commons@^0.0.1-beta.26, @cqse/commons@workspace:packages/cqse-commons":
   version: 0.0.0-use.local
   resolution: "@cqse/commons@workspace:packages/cqse-commons"
   dependencies:
@@ -1764,7 +1764,7 @@ __metadata:
   dependencies:
     "@babel/core": ^7.14.0
     "@babel/preset-env": ^7.14.1
-    "@cqse/commons": ^0.0.1-beta.25
+    "@cqse/commons": ^0.0.1-beta.26
     "@types/argparse": ^2.0.5
     "@types/async": ^3.2.6
     "@types/jest": ^27.0.1
@@ -1789,7 +1789,7 @@ __metadata:
     ts-node: ^10.2.1
     typescript: ^4.4.3
     typescript-optional: ^2.0.1
-    winston: ^3.3.3
+    winston: ^3.6.0
     ws: ^7.4.5
   bin:
     coverage-collector: dist/src/main.js
@@ -10209,7 +10209,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"winston@npm:*, winston@npm:^3.3.3":
+"winston@npm:*, winston@npm:^3.3.3, winston@npm:^3.6.0":
   version: 3.6.0
   resolution: "winston@npm:3.6.0"
   dependencies:


### PR DESCRIPTION
Addresses issue [TS-29729](https://cqse.atlassian.net/browse/TS-29729)

- [ ] Changes are tested adequately
- [ ] CHANGELOG.md of the affected packages are updated

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config needs adjustment, please state so in a comment and discuss this with your reviewer.


