### PR TITLE
fix: pass document.location to worker

### DIFF
--- a/packages/teamscale-javascript-instrumenter/src/vaccine/main.ts
+++ b/packages/teamscale-javascript-instrumenter/src/vaccine/main.ts
@@ -2,7 +2,8 @@
 // @ts-ignore: DataWorker import is handled by Esbuild---see `esbuild.mjs` and `workers.d.ts`
 import DataWorker from './worker/vaccine.worker.ts';
 import { getWindow, universe, universeAttribute } from './utils';
-import {createCoverageBuffer, FileCoverageBuffer} from "./buffer";
+import { createCoverageBuffer, FileCoverageBuffer } from "./buffer";
+import { LocationMessage } from './types.ts';
 
 // Prepare our global JavaScript object. This will hold
 // a reference to the WebWorker thread.
@@ -24,9 +25,9 @@ function setWorker(worker: DataWorker): DataWorker {
 }
 
 // Create a coverage buffer on the main window side.
-const coverageBuffer = createCoverageBuffer(250,(buffer: Map<string, FileCoverageBuffer>) => {
+const coverageBuffer = createCoverageBuffer(250, (buffer: Map<string, FileCoverageBuffer>) => {
 	for (const fileEntry of buffer.entries()) {
-		getWorker().postMessage([ fileEntry[0], Array.from(fileEntry[1].lines) ]);
+		getWorker().postMessage([fileEntry[0], Array.from(fileEntry[1].lines)]);
 	}
 });
 
@@ -40,6 +41,9 @@ if (!getWorker()) {
 	// Create the worker with the worker code
 	// (we use the tool 'rollup' to produce this object---see rollup.config.js)
 	const worker = setWorker(new DataWorker());
+
+	const message: LocationMessage = { type: 'location', host: document.location.host, port: document.location.port }
+	worker.postMessage(message);
 
 	(function handleUnloading() {
 		const vaccineUnloadHandler = () => {

--- a/packages/teamscale-javascript-instrumenter/src/vaccine/types.ts
+++ b/packages/teamscale-javascript-instrumenter/src/vaccine/types.ts
@@ -36,3 +36,11 @@ export interface CollectorSpecifierRelative {
  * Specifies how the vaccine can reach the collector.
  */
 export type CollectorSpecifier = CollectorSpecifierUrl | CollectorSpecifierRelative
+
+export interface LocationMessage {
+	type: 'location';
+	host: string;
+	port: string;
+}
+
+export type WorkerMessage = LocationMessage

--- a/packages/teamscale-javascript-instrumenter/src/vaccine/worker/CollectorUrlResolver.ts
+++ b/packages/teamscale-javascript-instrumenter/src/vaccine/worker/CollectorUrlResolver.ts
@@ -4,12 +4,12 @@ import { CollectorSpecifier, CollectorSpecifierRelative } from "../types";
 export class CollectorUrlResolver {
 
     /** Resolves the collector URL. */
-    static resolve(specifier: CollectorSpecifier): string {
+    static resolve(specifier: CollectorSpecifier, host: string, port: string): string {
         switch (specifier.type) {
             case 'url':
                 return specifier.url;
             case 'relative':
-                return CollectorUrlResolver.resolveRelative(location.host, location.port, specifier);
+                return CollectorUrlResolver.resolveRelative(host, port, specifier);
         }
     }
 

--- a/packages/teamscale-javascript-instrumenter/src/vaccine/worker/SocketWithRecovery.ts
+++ b/packages/teamscale-javascript-instrumenter/src/vaccine/worker/SocketWithRecovery.ts
@@ -1,24 +1,21 @@
 /**
  * A socket wrapper that caches messages in case
  * the connection was lost or not yet established.
+ * 
+ * Callers must call #connect() to establish the initial connection.
  */
 export class SocketWithRecovery {
 
 	/** The target URL to send messages to. */
-	private readonly url: string;
+	private url: string;
 
 	/** The wrapped WebSocket */
-	private socket: WebSocket;
+	private socket: WebSocket | null;
 
 	/** The messages that have been cached */
 	private cachedMessages: string[] = [];
 
-	/**
-	 * Constructor.
-	 *
-	 * @param url - The URL to send messages to.
-	 */
-	constructor(url: string) {
+	connect(url: string) {
 		this.url = url;
 		this.socket = this.createSocket();
 	}
@@ -46,7 +43,7 @@ export class SocketWithRecovery {
 	private onopen() {
 		// eslint-disable-next-line no-console
 		console.log('Connection to Coverage Collector established.');
-		this.cachedMessages.forEach(message => this.socket.send(message));
+		this.cachedMessages.forEach(message => this.socket!!.send(message));
 		this.cachedMessages = [];
 	}
 
@@ -55,7 +52,7 @@ export class SocketWithRecovery {
 	 * has not yet been established.
 	 */
 	public send(message: string): void {
-		if (this.socket.readyState === WebSocket.OPEN) {
+		if (this.socket !== null && this.socket.readyState === WebSocket.OPEN) {
 			this.socket.send(message);
 		} else {
 			// socket has not been opened yet for the first time

--- a/packages/teamscale-javascript-instrumenter/src/vaccine/worker/vaccine.worker.ts
+++ b/packages/teamscale-javascript-instrumenter/src/vaccine/worker/vaccine.worker.ts
@@ -4,7 +4,7 @@
  */
 import { SocketWithRecovery } from './SocketWithRecovery';
 import { CoverageAggregator } from './CoverageAggregator';
-import { CollectorSpecifier } from "../types";
+import { CollectorSpecifier, LocationMessage } from "../types";
 import { CollectorUrlResolver } from './CollectorUrlResolver';
 
 console.log('Starting coverage forwarding worker.');
@@ -13,7 +13,7 @@ console.log('Starting coverage forwarding worker.');
 // into the code to record coverage for.
 declare const $COLLECTOR_SPECIFIER: CollectorSpecifier
 
-const socket = new SocketWithRecovery(`${CollectorUrlResolver.resolve($COLLECTOR_SPECIFIER)}/socket`);
+const socket = new SocketWithRecovery();
 const aggregator = new CoverageAggregator(socket);
 
 // Handling of the messages the WebWorker receives
@@ -26,6 +26,10 @@ onmessage = (event: MessageEvent) => {
 	} else if (event.data === 'unload') {
 		// Send all information immediately
 		aggregator.flush();
+	} else if (event.data.type === "location") {
+		const locationMessage = event.data as LocationMessage;
+		const url = CollectorUrlResolver.resolve($COLLECTOR_SPECIFIER, locationMessage.host, locationMessage.port)
+		socket.connect(`${url}/socket`);
 	} else {
 		console.error(`No handler for message: ${event.data}`);
 	}


### PR DESCRIPTION
worker location was empty due to the way we construct the worker in-memory

Addresses issue [TS-38454](https://cqse.atlassian.net/browse/TS-38454)

- [ ] No findings in [Teamscale](https://demo.teamscale.com/activity.html#/teamscale-javascript-profiler/) (c.f. vote of the Teamscale Bot). Flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config needs adjustment, please state so in a comment and discuss this with your reviewer.
- [ ] Changes are tested adequately
- [ ] Profilers's README.md and the Teamscale documentation are updated in case of user-visible changes
- [ ] CHANGELOG.md of the affected packages are updated
- [ ] Present new features in [N&N](https://wiki.cqse.eu/pages/viewpage.action?pageId=689566)



